### PR TITLE
feature/update-ci-trigger-condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,6 @@ name: Python CI
 
 on:
   push:
-    branches:
-      - main
-      - develop
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## :rocket: Features

This PR will solve the issue when CI wouldn't run for the new commit push in the PR.
By removing the branch filters in the CI yaml, we can allow all the commits to be covered by CI.